### PR TITLE
Feature/not found error middleware

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
       files: ["*.ts", "*.tsx"],
       rules: {
         "no-implicit-coercion": "off",
+        "@typescript-eslint/consistent-type-assertions": "off",
       },
     },
   ],

--- a/src/server/middlewares/notFoundError/notFoundError.test.ts
+++ b/src/server/middlewares/notFoundError/notFoundError.test.ts
@@ -1,0 +1,16 @@
+import type { NextFunction, Request, Response } from "express";
+import notFoundError from "./notFoundError.js";
+
+describe("Given a notFoundError middleware", () => {
+  describe("When it receives a request", () => {
+    test("Then it should call its next method", () => {
+      const req = {} as Request;
+      const res = {} as Response;
+      const next = jest.fn() as NextFunction;
+
+      notFoundError(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/middlewares/notFoundError/notFoundError.ts
+++ b/src/server/middlewares/notFoundError/notFoundError.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, Response } from "express";
+import CustomError from "../../../CustomError/CustomError.js";
+
+const notFoundError = (req: Request, res: Response, next: NextFunction) => {
+  const message = "Enpoint not found";
+  const publicMessage = message;
+  const statusCode = 404;
+
+  const error = new CustomError(message, statusCode, publicMessage);
+
+  next(error);
+};
+
+export default notFoundError;


### PR DESCRIPTION
notFoundError middleware
 - Nexts a custom error with a status code 400 when an endpoint is not reached.

.eslintrc.cjs
 - Add rule: "@typescript-eslint/consistent-type-assertions": "off"