### PR TITLE
Delete a ESLint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,6 @@ module.exports = {
       files: ["*.ts", "*.tsx"],
       rules: {
         "no-implicit-coercion": "off",
-        "@typescript-eslint/consistent-type-assertions": "off",
       },
     },
   ],


### PR DESCRIPTION
Delete "@typescript-eslint/consistent-type-assertions" rule from eslintrc.cjs